### PR TITLE
Fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The goals that run analysis save the generated reports in the end of the plugin 
 ## Configuration Parameters
 
 **Common parameters:**
+
 Parameter | Description | Required? | Default
 --- | --- | --- | ---
 skip                           | Skip the plugin execution (equivalent CLI property: zap.skip)        | No  | false


### PR DESCRIPTION
The Common settings table was not rendered due to missing newline.
