### PR TITLE
Added the possibility to override ZAP Jvm arguments and documentation of configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,10 @@ zapPort              | Port where ZAP is running or will run                    
 zapHost              | Host where ZAP is running                                                   | No  | localhost
 zapApiKey            | API key needed to access ZAP's API, in case it's enabled                    | No  | -
 zapPath              | Absolute path where ZAP is installed, used to automatically start ZAP       | No  | -
+zapJvmOptions        | JVM options used to launch ZAP                                              | No  | -Xmx512m
 shouldRunWithDocker  | Indicates whether ZAP should be automatically started with Docker           | No  | false
 zapOptions           | Options that will be used to automatically start ZAP                        | No  | See bellow
-initializationTimeoutInMillis | ZAP's automatic initialization timeout in milliseconds    | No  | 120
+initializationTimeoutInMillis | ZAP's automatic initialization timeout in milliseconds    | No  | 120000
 reportPath  | Absolute or relative path where the generated reports will be saved         | No  | ${user.dir}/target/zapReports
 
 > To automatically start ZAP, it must be installed locally and the option *zapPath* must be provided. If the installation folder contains more than one Jar, *zapPath* should point to the core Jar file. To start ZAP with Docker, Docker must be locally installed and the option *shouldRunWithDocker* must be passed as *true*. In both cases, by default, ZAP is initialized with the following options:

--- a/zap-maven-plugin-core/src/main/java/br/com/softplan/security/zap/maven/ZapMojo.java
+++ b/zap-maven-plugin-core/src/main/java/br/com/softplan/security/zap/maven/ZapMojo.java
@@ -29,14 +29,46 @@ public abstract class ZapMojo extends AbstractMojo {
     @Parameter(property = "zap.skip", defaultValue = "false") private boolean skip;
     
 	// Analysis
+    /**
+     * URL of the application that will be scanned.
+     */
 	@Parameter(required=true) private String targetUrl;
+	
+	/**
+	 * Starting point URL for the Spider (and AJAX Spider, in case it runs).
+	 */
 	@Parameter private String spiderStartingPointUrl;
+	
+	/**
+	 * Starting point URL for the Active Scan.
+	 */
 	@Parameter private String activeScanStartingPointUrl;
+	
+	/**
+	 * The URLs to be set on ZAP's context (absolute or relative).
+	 */
 	@Parameter private String[] context;
+	
 	@Parameter private String[] technologies;
+	
+	/**
+	 * Analysis timeout in minutes.
+	 */
 	@Parameter(defaultValue="480")   private int analysisTimeoutInMinutes;
+	
+	/**
+	 * Indicates whether ZAP should execute the AJAX Spider after the default Spider (it can improve the scan on applications that rely on AJAX).
+	 */
 	@Parameter(defaultValue="false") private boolean shouldRunAjaxSpider;
+	
+	/**
+	 * In case it's true, the Active Scan will not be executed.
+	 */
 	@Parameter(defaultValue="false") private boolean shouldRunPassiveScanOnly;
+	
+	/**
+	 * Indicates whether a new session should be started on ZAP before the analysis.
+	 */
 	@Parameter(defaultValue="true")  private boolean shouldStartNewSession;
 	
 	// ZAP
@@ -86,28 +118,87 @@ public abstract class ZapMojo extends AbstractMojo {
 	@Parameter private File reportPath;
 
 	// Authentication
+	/**
+	 * Define the authentication type: 'http', 'form', 'cas' or 'selenium'.
+	 */
 	@Parameter private String authenticationType;
+	
+	/**
+	 * Login page URL.
+	 */
 	@Parameter private String loginUrl;
+	
+	/**
+	 * Username used in the authentication.
+	 */
 	@Parameter private String username;
+	
+	/**
+	 * Password used in the authentication.
+	 */
 	@Parameter private String password;
+	
+	/**
+	 * Used to define any extra parameters that must be passed in the authentication request (e.g. domain=someDomain&amp;param=value)
+	 */
 	@Parameter private String extraPostData;
+	
+	/**
+	 * Regex that identifies a pattern in authenticated responses (needed to allow re-authentication).
+	 */
 	@Parameter private String loggedInRegex;
+	
+	/**
+	 * Regex that identifies a pattern in non-authenticated responses (needed to allow re-authentication).
+	 */
 	@Parameter private String loggedOutRegex;
+	
+	/**
+	 * Define the URLs regexs that will be excluded from the scan.
+	 */
 	@Parameter private String[] excludeFromScan;
 	
 	// CAS
+	/**
+	 * Define the URL of a protected page of the application that will be scanned.
+	 */
 	@Parameter private String[] protectedPages;
 
 	// Form and Selenium
+	/**
+	 * Name of the request parameter that holds the username.
+	 */
 	@Parameter(defaultValue="username") private String usernameParameter;
+	
+	/**
+	 * Name of the request parameter that holds the password.
+	 */
 	@Parameter(defaultValue="password") private String passwordParameter;
 	
+	/**
+	 * Any additional session tokens that should be added to ZAP prior authentication.
+	 */
 	@Parameter private String[] httpSessionTokens;
+	
+	/**
+	 * The web driver that will be used to perform authentication: 'htmlunit', 'firefox', or 'phantomjs'.
+	 */
 	@Parameter(defaultValue="firefox") private String seleniumDriver;
 	
 	// HTTP
+	/**
+	 * The host name of the server where the authentication is done.
+	 */
 	@Parameter private String hostname;
+	
+	/**
+	 * The realm the credentials apply to.
+	 */
 	@Parameter private String realm;
+	
+	/**
+	 * The port of the server where the authentication is done.
+	 */
 	@Parameter(defaultValue="80") private int port;
 	
 	protected ZapInfo buildZapInfo() {

--- a/zap-maven-plugin-core/src/main/java/br/com/softplan/security/zap/maven/ZapMojo.java
+++ b/zap-maven-plugin-core/src/main/java/br/com/softplan/security/zap/maven/ZapMojo.java
@@ -26,7 +26,7 @@ public abstract class ZapMojo extends AbstractMojo {
 	/**
      * Disables the plug-in execution.
      */
-    @Parameter( property = "zap.skip", defaultValue = "false") private boolean skip;
+    @Parameter(property = "zap.skip", defaultValue = "false") private boolean skip;
     
 	// Analysis
 	@Parameter(required=true) private String targetUrl;
@@ -40,13 +40,49 @@ public abstract class ZapMojo extends AbstractMojo {
 	@Parameter(defaultValue="true")  private boolean shouldStartNewSession;
 	
 	// ZAP
+	/**
+	 * Port where ZAP is running or will run.
+	 */
 	@Parameter(required=true) private Integer zapPort;
-	@Parameter private String zapHost;
-	@Parameter private String zapApiKey;
+	
+	/**
+	 * Host where ZAP is running.
+	 */
+	@Parameter(defaultValue="localhost") private String zapHost;
+	
+	/**
+	 * API key needed to access ZAP's API, in case it's enabled.
+	 */
+	@Parameter(defaultValue="") private String zapApiKey;
+	
+	/**
+	 * Absolute path where ZAP is installed, used to automatically start ZAP.
+	 */
 	@Parameter private String zapPath;
-	@Parameter private String zapOptions;
-	@Parameter private boolean shouldRunWithDocker;
+	
+	/**
+	 * JVM options used to launch ZAP.
+	 */
+	@Parameter(defaultValue="-Xmx512m") private String zapJvmOptions;
+	
+	/**
+	 * Options that will be used to automatically start ZAP.
+	 */
+	@Parameter(defaultValue=ZapInfo.DEFAULT_OPTIONS) private String zapOptions;
+	
+	/**
+	 * Indicates whether ZAP should be automatically started with Docker.
+	 */
+	@Parameter(defaultValue="false") private boolean shouldRunWithDocker;
+	
+	/**
+	 * ZAP's automatic initialization timeout in milliseconds.
+	 */
 	@Parameter(defaultValue="120000") private Integer initializationTimeoutInMillis;
+	
+	/**
+	 * Absolute or relative path where the generated reports will be saved.
+	 */
 	@Parameter private File reportPath;
 
 	// Authentication
@@ -80,6 +116,7 @@ public abstract class ZapMojo extends AbstractMojo {
 				.port   (zapPort)
 				.apiKey (zapApiKey)
 				.path   (zapPath)
+				.jmvOptions(zapJvmOptions)
 				.options(zapOptions)
 				.initializationTimeoutInMillis((long) initializationTimeoutInMillis)
 				.shouldRunWithDocker(shouldRunWithDocker)

--- a/zap-utils/src/main/java/br/com/softplan/security/zap/commons/ZapInfo.java
+++ b/zap-utils/src/main/java/br/com/softplan/security/zap/commons/ZapInfo.java
@@ -23,15 +23,17 @@ public final class ZapInfo {
 
 	private static final String DEFAULT_HOST = "localhost";
 	private static final String DEFAULT_KEY = "";
-	private static final long DEFAULT_INITIALIZATION_TIMEOUT_IN_MILLIS  = 120 * 1000;
-	private static final String DEFAULT_OPTIONS = "-daemon -config api.disablekey=true -config api.incerrordetails=true -config proxy.ip=0.0.0.0";
+	private static final Long DEFAULT_INITIALIZATION_TIMEOUT_IN_MILLIS  = new Long(120000);
+	private static final String DEFAULT_JVM_OPTIONS = "-Xmx512m";
+	public static final String DEFAULT_OPTIONS = "-daemon -config api.disablekey=true -config api.incerrordetails=true -config proxy.ip=0.0.0.0";
 	
 	private String host;
 	private Integer port;
 	private String apiKey;
 	private String path;
+	private String jmvOptions;
 	private String options;
-	private long initializationTimeoutInMillis;
+	private Long initializationTimeoutInMillis;
 	private boolean shouldRunWithDocker;
 	
 	public static Builder builder() {
@@ -54,6 +56,10 @@ public final class ZapInfo {
 		return path;
 	}
 
+	public String getJmvOptions() {
+		return jmvOptions;
+	}
+	
 	public String getOptions() {
 		return options;
 	}
@@ -72,6 +78,7 @@ public final class ZapInfo {
 		private Integer port;
 		private String apiKey = DEFAULT_KEY;
 		private String path;
+		private String jmvOptions = DEFAULT_JVM_OPTIONS;
 		private String options = DEFAULT_OPTIONS;
 		private Long initializationTimeoutInMillis = DEFAULT_INITIALIZATION_TIMEOUT_IN_MILLIS;
 		private boolean shouldRunWithDocker; 
@@ -238,6 +245,20 @@ public final class ZapInfo {
 		}
 		
 		/**
+		 * Sets the JVM options used to run ZAP.
+		 * <p>
+		 * This should be used when ZAP is installed locally and it is automatically started and stopped.
+		 * 
+		 * @param jmvOptions the JVM options used to start ZAP.
+		 * @return this {@code Builder} instance.
+		 * @see #path(String)
+		 */
+		public Builder jmvOptions(String jmvOptions) {
+			this.jmvOptions = jmvOptions;
+			return this;
+		}
+		
+		/**
 		 * Sets the options used to start ZAP.
 		 * <p>
 		 * This should be used to overwrite the default options used to start ZAP (locally or in a Docker image). 
@@ -299,6 +320,7 @@ public final class ZapInfo {
 		this.port                  = builder.port;
 		this.apiKey                = builder.apiKey;
 		this.path                  = builder.path;
+		this.jmvOptions            = builder.jmvOptions;
 		this.options               = builder.options;
 		this.initializationTimeoutInMillis = builder.initializationTimeoutInMillis;
 		this.shouldRunWithDocker   = builder.shouldRunWithDocker;
@@ -311,6 +333,7 @@ public final class ZapInfo {
 				.append("port", port)
 				.append("apiKey", apiKey)
 				.append("path", path)
+				.append("jvmOptions", jmvOptions)
 				.append("options", options)
 				.append("initializationTimeout", initializationTimeoutInMillis)
 				.append("shouldRunWithDocker", shouldRunWithDocker)

--- a/zap-utils/src/main/java/br/com/softplan/security/zap/commons/boot/ZapLocalBoot.java
+++ b/zap-utils/src/main/java/br/com/softplan/security/zap/commons/boot/ZapLocalBoot.java
@@ -25,8 +25,6 @@ public class ZapLocalBoot extends AbstractZapBoot {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ZapLocalBoot.class);
 	
-	private static final String DEFAULT_ZAP_START_COMMAND = "java -Xmx512m -jar ";
-	
 	private static Process zap;
 	
 	@Override
@@ -67,7 +65,11 @@ public class ZapLocalBoot extends AbstractZapBoot {
 	}
 	
 	private static String buildStartCommand(ZapInfo zapInfo) {
-		StringBuilder startCommand = new StringBuilder(DEFAULT_ZAP_START_COMMAND);
+		StringBuilder startCommand = new StringBuilder();
+		
+		startCommand.append("java").append(" ");
+		startCommand.append(zapInfo.getJmvOptions()).append(" ");
+		startCommand.append("-jar").append(" ");
 		
 		try {
 			String zapJarName = retrieveZapJarName(zapInfo.getPath());


### PR DESCRIPTION
In our use-case the -Xmx512m jvm setting is not sufficient to run the tests. The plugin had this setting hardcoded.
I introduced a new setting 'zapJvmOptions' that is defaulted to -Xmx512m (as before).

The configuration settings are now documented in the code: this allow IDEs like Eclipse to show the documentation while configuring the plugin in a pom file.
