### PR TITLE
New default value for reportPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ zapJvmOptions        | JVM options used to launch ZAP                           
 shouldRunWithDocker  | Indicates whether ZAP should be automatically started with Docker           | No  | false
 zapOptions           | Options that will be used to automatically start ZAP                        | No  | See bellow
 initializationTimeoutInMillis | ZAP's automatic initialization timeout in milliseconds    | No  | 120000
-reportPath  | Absolute or relative path where the generated reports will be saved         | No  | ${user.dir}/target/zapReports
+reportPath  | Absolute or relative path where the generated reports will be saved         | No  | ${project.build.directory}/zap-reports
 
 > To automatically start ZAP, it must be installed locally and the option *zapPath* must be provided. If the installation folder contains more than one Jar, *zapPath* should point to the core Jar file. To start ZAP with Docker, Docker must be locally installed and the option *shouldRunWithDocker* must be passed as *true*. In both cases, by default, ZAP is initialized with the following options:
 > ```

--- a/zap-maven-plugin-core/src/main/java/br/com/softplan/security/zap/maven/ZapMojo.java
+++ b/zap-maven-plugin-core/src/main/java/br/com/softplan/security/zap/maven/ZapMojo.java
@@ -115,7 +115,7 @@ public abstract class ZapMojo extends AbstractMojo {
 	/**
 	 * Absolute or relative path where the generated reports will be saved.
 	 */
-	@Parameter private File reportPath;
+	@Parameter(defaultValue="${project.build.directory}/zap-reports") private File reportPath;
 
 	// Authentication
 	/**


### PR DESCRIPTION
Hi all,

I checked the code and I see that the default path for generated reports is: ${user.dir}/target/zapReports

Usually the output of the build should be put in the target folder of the project that can be referenced using the ${project.build.directory}. The value of ${project.build.directory} is equal to ${user.dir}/target only when the user launches the build from the directory where pom is placed and the "target" folder is used.

My proposal is to change the default value to ${project.build.directory}/zap-reports

Please note that I changed 'zapReports' into 'zap-reports': many plugins use this _kebab-case_ or _spinal-case_

What is your opinion on this enhancement?
